### PR TITLE
chore: bump gha versions to current

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
           cache: true

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
           cache: true


### PR DESCRIPTION
## What changed?
- Updated GHA versions

## How to test
- [x] `make rebuild`
- [x] `make format`
- [x] `make lint`
- [x] `make ci`

## Notes (optional)
- Resolves PRs #1 and #2 
