### PR TITLE
Fix: Removed materials students haven't learned yet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ coverage/
 
 # Logs
 *.log
+
+# Mac messing up
+csci-1302-lab.sln

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ tool-restore:
 format: tool-restore
 	$(DOTNET) csharpier format .
 
-lint: tool-restore
+lint: format tool-restore
 	$(DOTNET) csharpier check .
 	$(DOTNET) build "$(SLN)" -c "$(CONFIG)" --nologo
 

--- a/src/labs/01-uml/CS1302.Lab01.Uml/Models/Book.cs
+++ b/src/labs/01-uml/CS1302.Lab01.Uml/Models/Book.cs
@@ -1,6 +1,6 @@
 namespace CS1302.Lab01.Uml.Models;
 
-public sealed class Book
+public class Book
 {
     public Book(string title, string author)
     {

--- a/src/labs/01-uml/CS1302.Lab01.Uml/Models/Library.cs
+++ b/src/labs/01-uml/CS1302.Lab01.Uml/Models/Library.cs
@@ -1,38 +1,61 @@
 namespace CS1302.Lab01.Uml.Models;
 
-public sealed class Library
+public class Library
 {
-    private readonly List<Book> _books = new();
-
-    public IReadOnlyList<Book> Books => _books;
+    public List<Book> Books { get; } = new List<Book>();
 
     public void AddBook(Book book)
     {
-        ArgumentNullException.ThrowIfNull(book);
-        _books.Add(book);
+        if (book == null)
+        {
+            throw new ArgumentNullException(nameof(book));
+        }
+
+        Books.Add(book);
     }
 
     public Book? FindByTitle(string title)
     {
-        if (string.IsNullOrWhiteSpace(title))
+        if (title == null)
+        {
+            throw new ArgumentNullException(nameof(title));
+        }
+
+        if (title.Trim().Length == 0)
         {
             return null;
         }
 
-        return _books.FirstOrDefault(b =>
-            string.Equals(b.Title, title, StringComparison.OrdinalIgnoreCase)
-        );
+        for (int i = 0; i < Books.Count; i++)
+        {
+            Book b = Books[i];
+
+            if (string.Equals(b.Title, title, StringComparison.OrdinalIgnoreCase))
+            {
+                return b;
+            }
+        }
+
+        return null;
     }
 
     public void CheckOut(Book book)
     {
-        ArgumentNullException.ThrowIfNull(book);
+        if (book == null)
+        {
+            throw new ArgumentNullException(nameof(book));
+        }
+
         book.CheckOut();
     }
 
     public void Return(Book book)
     {
-        ArgumentNullException.ThrowIfNull(book);
+        if (book == null)
+        {
+            throw new ArgumentNullException(nameof(book));
+        }
+
         book.Return();
     }
 }

--- a/src/labs/01-uml/CS1302.Lab01.Uml/Program.cs
+++ b/src/labs/01-uml/CS1302.Lab01.Uml/Program.cs
@@ -6,7 +6,7 @@ public static class Program
 {
     public static void Main()
     {
-        var library = new Library();
+        Library library = new Library();
 
         library.AddBook(new Book("Dune", "Frank Herbert"));
         library.AddBook(new Book("The Hobbit", "J.R.R. Tolkien"));
@@ -16,8 +16,8 @@ public static class Program
 
         Console.WriteLine();
         Console.WriteLine("Checking out 'Dune'...");
-        var dune = library.FindByTitle("Dune");
-        if (dune is not null)
+        Book? dune = library.FindByTitle("Dune");
+        if (dune != null)
         {
             library.CheckOut(dune);
         }
@@ -26,7 +26,7 @@ public static class Program
 
         Console.WriteLine();
         Console.WriteLine("Returning 'Dune'...");
-        if (dune is not null)
+        if (dune != null)
         {
             library.Return(dune);
         }
@@ -37,7 +37,7 @@ public static class Program
     private static void PrintStatus(Library library)
     {
         Console.WriteLine("Library Inventory:");
-        foreach (var book in library.Books)
+        foreach (Book book in library.Books)
         {
             Console.WriteLine(
                 $"- {book.Title} by {book.Author} (Checked out: {book.IsCheckedOut})"

--- a/src/labs/02-arrays-1d/CS1302.Lab02.Arrays1D/Exercises/ArraySearch.cs
+++ b/src/labs/02-arrays-1d/CS1302.Lab02.Arrays1D/Exercises/ArraySearch.cs
@@ -42,7 +42,9 @@ public static class ArraySearch
             throw new ArgumentNullException(nameof(to));
         }
 
-        StringComparison comparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        StringComparison comparison = ignoreCase
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
 
         int replaced = 0;
         for (int i = 0; i < values.Length; i++)

--- a/src/labs/02-arrays-1d/CS1302.Lab02.Arrays1D/Exercises/ArraySearch.cs
+++ b/src/labs/02-arrays-1d/CS1302.Lab02.Arrays1D/Exercises/ArraySearch.cs
@@ -42,7 +42,7 @@ public static class ArraySearch
             throw new ArgumentNullException(nameof(to));
         }
 
-        var comparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        StringComparison comparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 
         int replaced = 0;
         for (int i = 0; i < values.Length; i++)

--- a/src/labs/02-arrays-1d/CS1302.Lab02.Arrays1D/Exercises/ArrayStats.cs
+++ b/src/labs/02-arrays-1d/CS1302.Lab02.Arrays1D/Exercises/ArrayStats.cs
@@ -1,12 +1,10 @@
 namespace CS1302.Lab02.Arrays1D.Exercises;
 
-public readonly record struct StatsResult(int Min, int Max, double Average, int EvenCount);
-
 public static class ArrayStats
 {
-    public static StatsResult Compute(int[] values)
+    public static double[] Compute(int[] values)
     {
-        if (values is null)
+        if (values == null)
         {
             throw new ArgumentNullException(nameof(values));
         }
@@ -21,12 +19,12 @@ public static class ArrayStats
         long sum = 0;
         int evenCount = 0;
 
-        foreach (int v in values)
+        for (int i = 0; i < values.Length; i++)
         {
-            if (v < min)
-                min = v;
-            if (v > max)
-                max = v;
+            int v = values[i];
+
+            if (v < min) min = v;
+            if (v > max) max = v;
 
             sum += v;
 
@@ -37,6 +35,7 @@ public static class ArrayStats
         }
 
         double avg = (double)sum / values.Length;
-        return new StatsResult(min, max, avg, evenCount);
+
+        return new double[] { min, max, avg, evenCount };
     }
 }

--- a/src/labs/02-arrays-1d/CS1302.Lab02.Arrays1D/Exercises/ArrayStats.cs
+++ b/src/labs/02-arrays-1d/CS1302.Lab02.Arrays1D/Exercises/ArrayStats.cs
@@ -23,8 +23,10 @@ public static class ArrayStats
         {
             int v = values[i];
 
-            if (v < min) min = v;
-            if (v > max) max = v;
+            if (v < min)
+                min = v;
+            if (v > max)
+                max = v;
 
             sum += v;
 

--- a/src/labs/02-arrays-1d/CS1302.Lab02.Arrays1D/Program.cs
+++ b/src/labs/02-arrays-1d/CS1302.Lab02.Arrays1D/Program.cs
@@ -13,11 +13,11 @@ public static class Program
 
         Console.WriteLine();
         Console.WriteLine("-- Stats --");
-        StatsResult stats = ArrayStats.Compute(numbers);
-        Console.WriteLine($"Min: {stats.Min}");
-        Console.WriteLine($"Max: {stats.Max}");
-        Console.WriteLine($"Avg: {stats.Average:F2}");
-        Console.WriteLine($"EvenCount: {stats.EvenCount}");
+        double[] stats = ArrayStats.Compute(numbers);
+        Console.WriteLine($"Min: {stats[0]}");
+        Console.WriteLine($"Max: {stats[1]}");
+        Console.WriteLine($"Avg: {stats[2]:F2}");
+        Console.WriteLine($"EvenCount: {stats[3]}");
 
         Console.WriteLine();
         Console.WriteLine("-- Search + Replace --");

--- a/src/labs/02-arrays-1d/CS1302.Lab02.Arrays1D/Program.cs
+++ b/src/labs/02-arrays-1d/CS1302.Lab02.Arrays1D/Program.cs
@@ -13,7 +13,7 @@ public static class Program
 
         Console.WriteLine();
         Console.WriteLine("-- Stats --");
-        var stats = ArrayStats.Compute(numbers);
+        StatsResult stats = ArrayStats.Compute(numbers);
         Console.WriteLine($"Min: {stats.Min}");
         Console.WriteLine($"Max: {stats.Max}");
         Console.WriteLine($"Avg: {stats.Average:F2}");
@@ -27,7 +27,7 @@ public static class Program
         int replaced = ArraySearch.ReplaceAll(words, "cat", "fox", ignoreCase: true);
         Console.WriteLine($"Replaced: {replaced}");
         Console.WriteLine("Updated array:");
-        foreach (var w in words)
+        foreach (string w in words)
         {
             Console.WriteLine($"- {w}");
         }

--- a/src/labs/03-arrays-2d/CS1302.Lab03.Arrays2D/Exercises/GridMath.cs
+++ b/src/labs/03-arrays-2d/CS1302.Lab03.Arrays2D/Exercises/GridMath.cs
@@ -64,7 +64,10 @@ public static class GridMath
 
         if (rows == 0 || cols == 0)
         {
-            throw new ArgumentException("Grid must have at least 1 row and 1 column.", nameof(grid));
+            throw new ArgumentException(
+                "Grid must have at least 1 row and 1 column.",
+                nameof(grid)
+            );
         }
 
         int bestVal = grid[0, 0];

--- a/src/labs/03-arrays-2d/CS1302.Lab03.Arrays2D/Exercises/GridMath.cs
+++ b/src/labs/03-arrays-2d/CS1302.Lab03.Arrays2D/Exercises/GridMath.cs
@@ -1,12 +1,10 @@
 namespace CS1302.Lab03.Arrays2D.Exercises;
 
-public readonly record struct MaxCell(int Value, int Row, int Col);
-
 public static class GridMath
 {
     public static int[] RowSums(int[,] grid)
     {
-        if (grid is null)
+        if (grid == null)
         {
             throw new ArgumentNullException(nameof(grid));
         }
@@ -14,7 +12,7 @@ public static class GridMath
         int rows = grid.GetLength(0);
         int cols = grid.GetLength(1);
 
-        int[]? sums = new int[rows];
+        int[] sums = new int[rows];
 
         for (int r = 0; r < rows; r++)
         {
@@ -31,7 +29,7 @@ public static class GridMath
 
     public static int[] ColumnSums(int[,] grid)
     {
-        if (grid is null)
+        if (grid == null)
         {
             throw new ArgumentNullException(nameof(grid));
         }
@@ -39,7 +37,7 @@ public static class GridMath
         int rows = grid.GetLength(0);
         int cols = grid.GetLength(1);
 
-        int[]? sums = new int[cols];
+        int[] sums = new int[cols];
 
         for (int c = 0; c < cols; c++)
         {
@@ -54,9 +52,9 @@ public static class GridMath
         return sums;
     }
 
-    public static MaxCell MaxValue(int[,] grid)
+    public static int[] MaxValue(int[,] grid)
     {
-        if (grid is null)
+        if (grid == null)
         {
             throw new ArgumentNullException(nameof(grid));
         }
@@ -66,10 +64,7 @@ public static class GridMath
 
         if (rows == 0 || cols == 0)
         {
-            throw new ArgumentException(
-                "Grid must have at least 1 row and 1 column.",
-                nameof(grid)
-            );
+            throw new ArgumentException("Grid must have at least 1 row and 1 column.", nameof(grid));
         }
 
         int bestVal = grid[0, 0];
@@ -90,6 +85,6 @@ public static class GridMath
             }
         }
 
-        return new MaxCell(bestVal, bestR, bestC);
+        return new int[] { bestVal, bestR, bestC };
     }
 }

--- a/src/labs/03-arrays-2d/CS1302.Lab03.Arrays2D/Exercises/GridMath.cs
+++ b/src/labs/03-arrays-2d/CS1302.Lab03.Arrays2D/Exercises/GridMath.cs
@@ -14,7 +14,7 @@ public static class GridMath
         int rows = grid.GetLength(0);
         int cols = grid.GetLength(1);
 
-        var sums = new int[rows];
+        int[]? sums = new int[rows];
 
         for (int r = 0; r < rows; r++)
         {
@@ -39,7 +39,7 @@ public static class GridMath
         int rows = grid.GetLength(0);
         int cols = grid.GetLength(1);
 
-        var sums = new int[cols];
+        int[]? sums = new int[cols];
 
         for (int c = 0; c < cols; c++)
         {

--- a/src/labs/03-arrays-2d/CS1302.Lab03.Arrays2D/Program.cs
+++ b/src/labs/03-arrays-2d/CS1302.Lab03.Arrays2D/Program.cs
@@ -27,7 +27,7 @@ public static class Program
 
         Console.WriteLine();
         Console.WriteLine("-- Max value + coordinates --");
-        var max = GridMath.MaxValue(grid);
+        MaxCell max = GridMath.MaxValue(grid);
         Console.WriteLine($"Max: {max.Value} at (row={max.Row}, col={max.Col})");
     }
 

--- a/src/labs/03-arrays-2d/CS1302.Lab03.Arrays2D/Program.cs
+++ b/src/labs/03-arrays-2d/CS1302.Lab03.Arrays2D/Program.cs
@@ -27,8 +27,8 @@ public static class Program
 
         Console.WriteLine();
         Console.WriteLine("-- Max value + coordinates --");
-        MaxCell max = GridMath.MaxValue(grid);
-        Console.WriteLine($"Max: {max.Value} at (row={max.Row}, col={max.Col})");
+        int[] max = GridMath.MaxValue(grid);
+        Console.WriteLine($"Max: {max[0]} at (row={max[1]}, col={max[2]})");
     }
 
     private static void PrintArray(int[] arr)

--- a/src/labs/04-properties-exceptions/CS1302.Lab04.PropertiesExceptions/Models/BankAccount.cs
+++ b/src/labs/04-properties-exceptions/CS1302.Lab04.PropertiesExceptions/Models/BankAccount.cs
@@ -1,6 +1,6 @@
 namespace CS1302.Lab04.PropertiesExceptions.Models;
 
-public sealed class BankAccount
+public class BankAccount
 {
     public BankAccount(string owner, decimal startingBalance)
     {

--- a/src/labs/04-properties-exceptions/CS1302.Lab04.PropertiesExceptions/Models/Temperature.cs
+++ b/src/labs/04-properties-exceptions/CS1302.Lab04.PropertiesExceptions/Models/Temperature.cs
@@ -1,6 +1,6 @@
 namespace CS1302.Lab04.PropertiesExceptions.Models;
 
-public sealed class Temperature
+public class Temperature
 {
     private const double AbsoluteZeroC = -273.15;
 

--- a/src/labs/04-properties-exceptions/CS1302.Lab04.PropertiesExceptions/Program.cs
+++ b/src/labs/04-properties-exceptions/CS1302.Lab04.PropertiesExceptions/Program.cs
@@ -10,7 +10,7 @@ public static class Program
 
         Console.WriteLine();
         Console.WriteLine("-- BankAccount --");
-        var acct = new BankAccount("Seth", 100m);
+        BankAccount acct = new BankAccount("Seth", 100m);
         Console.WriteLine(acct);
 
         acct.Deposit(25m);
@@ -32,7 +32,7 @@ public static class Program
 
         Console.WriteLine();
         Console.WriteLine("-- Temperature --");
-        var t = new Temperature(21.0);
+        Temperature t = new Temperature(21.0);
         Console.WriteLine($"C: {t.Celsius}, F: {t.Fahrenheit:F1}");
 
         Console.WriteLine("Trying invalid temperature...");

--- a/tests/CS1302.Labs.Tests/Lab01_Uml_Tests.cs
+++ b/tests/CS1302.Labs.Tests/Lab01_Uml_Tests.cs
@@ -8,7 +8,7 @@ public class Lab01_Uml_Tests
     [Fact]
     public void Book_CheckOut_Then_Return_Works()
     {
-        var book = new Book("Dune", "Frank Herbert");
+        Book book = new Book("Dune", "Frank Herbert");
 
         Assert.False(book.IsCheckedOut);
 
@@ -22,10 +22,10 @@ public class Lab01_Uml_Tests
     [Fact]
     public void Library_FindByTitle_IsCaseInsensitive()
     {
-        var lib = new Library();
+        Library lib = new Library();
         lib.AddBook(new Book("Dune", "Frank Herbert"));
 
-        var found = lib.FindByTitle("dUnE");
+        Book? found = lib.FindByTitle("dUnE");
         Assert.NotNull(found);
         Assert.Equal("Dune", found!.Title);
     }

--- a/tests/CS1302.Labs.Tests/Lab01_Uml_Tests.cs
+++ b/tests/CS1302.Labs.Tests/Lab01_Uml_Tests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace CS1302.Labs.Tests;
 
-public sealed class Lab01_Uml_Tests
+public class Lab01_Uml_Tests
 {
     [Fact]
     public void Book_CheckOut_Then_Return_Works()

--- a/tests/CS1302.Labs.Tests/Lab02_Arrays1D_Tests.cs
+++ b/tests/CS1302.Labs.Tests/Lab02_Arrays1D_Tests.cs
@@ -10,7 +10,7 @@ public class Lab02_Arrays1D_Tests
     {
         int[] values = { 2, 5, -1, 4 };
 
-        var result = ArrayStats.Compute(values);
+        StatsResult result = ArrayStats.Compute(values);
 
         Assert.Equal(-1, result.Min);
         Assert.Equal(5, result.Max);

--- a/tests/CS1302.Labs.Tests/Lab02_Arrays1D_Tests.cs
+++ b/tests/CS1302.Labs.Tests/Lab02_Arrays1D_Tests.cs
@@ -10,12 +10,12 @@ public class Lab02_Arrays1D_Tests
     {
         int[] values = { 2, 5, -1, 4 };
 
-        StatsResult result = ArrayStats.Compute(values);
+        double[] result = ArrayStats.Compute(values);
 
-        Assert.Equal(-1, result.Min);
-        Assert.Equal(5, result.Max);
-        Assert.Equal(2.5, result.Average, 5);
-        Assert.Equal(2, result.EvenCount);
+        Assert.Equal(-1, result[0]);
+        Assert.Equal(5, result[1]);
+        Assert.Equal(2.5, result[2], 5);
+        Assert.Equal(2, result[3]);
     }
 
     [Fact]

--- a/tests/CS1302.Labs.Tests/Lab02_Arrays1D_Tests.cs
+++ b/tests/CS1302.Labs.Tests/Lab02_Arrays1D_Tests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace CS1302.Labs.Tests;
 
-public sealed class Lab02_Arrays1D_Tests
+public class Lab02_Arrays1D_Tests
 {
     [Fact]
     public void Stats_Computes_MinMaxAvgEvenCount()

--- a/tests/CS1302.Labs.Tests/Lab03_Arrays2D_Tests.cs
+++ b/tests/CS1302.Labs.Tests/Lab03_Arrays2D_Tests.cs
@@ -27,7 +27,7 @@ public class Lab03_Arrays2D_Tests
             { 9, 3 },
         };
 
-        var max = GridMath.MaxValue(grid);
+        MaxCell max = GridMath.MaxValue(grid);
         Assert.Equal(9, max.Value);
         Assert.Equal(1, max.Row);
         Assert.Equal(0, max.Col);

--- a/tests/CS1302.Labs.Tests/Lab03_Arrays2D_Tests.cs
+++ b/tests/CS1302.Labs.Tests/Lab03_Arrays2D_Tests.cs
@@ -27,9 +27,9 @@ public class Lab03_Arrays2D_Tests
             { 9, 3 },
         };
 
-        MaxCell max = GridMath.MaxValue(grid);
-        Assert.Equal(9, max.Value);
-        Assert.Equal(1, max.Row);
-        Assert.Equal(0, max.Col);
+        int[] max = GridMath.MaxValue(grid);
+        Assert.Equal(9, max[0]);
+        Assert.Equal(1, max[1]);
+        Assert.Equal(0, max[2]);
     }
 }

--- a/tests/CS1302.Labs.Tests/Lab03_Arrays2D_Tests.cs
+++ b/tests/CS1302.Labs.Tests/Lab03_Arrays2D_Tests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace CS1302.Labs.Tests;
 
-public sealed class Lab03_Arrays2D_Tests
+public class Lab03_Arrays2D_Tests
 {
     [Fact]
     public void RowSums_And_ColumnSums_Work()

--- a/tests/CS1302.Labs.Tests/Lab04_PropsExceptions_Tests.cs
+++ b/tests/CS1302.Labs.Tests/Lab04_PropsExceptions_Tests.cs
@@ -8,7 +8,7 @@ public class Lab04_PropsExceptions_Tests
     [Fact]
     public void BankAccount_Rejects_Overdraft()
     {
-        var acct = new BankAccount("Test", 10m);
+        BankAccount acct = new BankAccount("Test", 10m);
 
         Assert.Throws<InvalidOperationException>(() => acct.Withdraw(11m));
         Assert.Equal(10m, acct.Balance);
@@ -17,7 +17,7 @@ public class Lab04_PropsExceptions_Tests
     [Fact]
     public void Temperature_Rejects_BelowAbsoluteZero()
     {
-        var t = new Temperature(0.0);
+        Temperature t = new Temperature(0.0);
 
         Assert.Throws<ArgumentOutOfRangeException>(() => t.Celsius = -999.0);
     }

--- a/tests/CS1302.Labs.Tests/Lab04_PropsExceptions_Tests.cs
+++ b/tests/CS1302.Labs.Tests/Lab04_PropsExceptions_Tests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace CS1302.Labs.Tests;
 
-public sealed class Lab04_PropsExceptions_Tests
+public class Lab04_PropsExceptions_Tests
 {
     [Fact]
     public void BankAccount_Rejects_Overdraft()


### PR DESCRIPTION
## What changed?
- Updated various files to remove references to topics student's haven't covered yet, including:
    - sealed
    - interfaces
    - struct
    - record
    - `is not null`
    - var

## How to test
- [x] `make rebuild`
- [x] `make format`
- [x] `make lint`
- [x] `make ci`


